### PR TITLE
Do not replace GitHub auto-link texts which contains space.

### DIFF
--- a/src/app/plugins/autolinking.js
+++ b/src/app/plugins/autolinking.js
@@ -785,12 +785,15 @@ export class GitHubLinkDataLoader {
 						let linkData;
 
 						if ( link ) {
+							const returnedText = link.textContent;
+
 							// Get the extra data from the link itself.
 							linkData = {
 								url: link.getAttribute( 'href' ),
 
 								// GitHub may have a different text for this as well. e.g. when pasting an issue url.
-								text: link.textContent,
+								// Ignore the returned text if it contains space (it's not a single word).
+								text: /\s/.test( returnedText ) ? text : returnedText,
 
 								// This enables hover cards on the auto-link.
 								'hovercard-type': link.getAttribute( 'data-hovercard-type' ),

--- a/tests/unit/plugins/autolinking/githublinkdataloader.js
+++ b/tests/unit/plugins/autolinking/githublinkdataloader.js
@@ -136,6 +136,38 @@ describe( 'Plugins', () => {
 					return promise;
 				} );
 
+				it( 'should resolve not return text with space', () => {
+					const loader = new GitHubLinkDataLoader();
+
+					let xhr;
+
+					sinonXhr.onCreate = createdXhr => ( xhr = createdXhr );
+
+					const promise = loader.load( 'test' )
+						.then( urlInfo => {
+							expect( urlInfo ).to.deep.equals( {
+								url: 'https://test.com/test',
+								text: 'test',
+								'hovercard-type': 'test-type',
+								'hovercard-url': '/test/hovercard'
+							} );
+						} );
+
+					expect( promise ).to.be.an.instanceOf( Promise );
+
+					checkXhr( xhr );
+
+					xhr.respond( 200, { 'Content-Type': 'text/html' },
+						'<p><a ' +
+						'data-hovercard-type="test-type" ' +
+						'data-hovercard-url="/test/hovercard" ' +
+						'href="https://test.com/test">' +
+						'response with space' +
+						'</a></p>' );
+
+					return promise;
+				} );
+
 				it( 'should take from cache on second call', () => {
 					const loader = new GitHubLinkDataLoader();
 


### PR DESCRIPTION
Fixes #66.