### PR TITLE
Bumping CKE5 to the latest version after recent release

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^25.4.0",
-    "@ckeditor/ckeditor5-dev-tests": "^25.4.0",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^6.4.1",
     "eslint": "^7.28.0",


### PR DESCRIPTION
Updated package.json file with never version of CKE5 dependencies, added the `dev-tests` package to devdependencies, as it is necessary for testing purposes.