### PR TITLE
Updated content border styling

### DIFF
--- a/src/github-writer.css
+++ b/src/github-writer.css
@@ -27,6 +27,10 @@ div.github-writer-ckeditor .ck-editor__editable {
 	min-height: inherit;
 }
 
+div.github-writer-ckeditor .ck-editor__editable.ck.ck-content {
+	border-radius: 6px;
+}
+
 div.github-writer-ckeditor .ck-editor__editable.ck-blurred {
 	background-color: var(--color-canvas-inset);
 }

--- a/src/github-writer.css
+++ b/src/github-writer.css
@@ -28,6 +28,7 @@ div.github-writer-ckeditor .ck-editor__editable {
 }
 
 div.github-writer-ckeditor .ck-editor__editable.ck.ck-content {
+	/* https://github.com/ckeditor/github-writer/issues/311 */
 	border-radius: 6px;
 }
 


### PR DESCRIPTION
Updated the border-radius value of `.ck-content` so the border is visible around the content correctly. Closes #311.