### PR TITLE
Updated manifest to v3

### DIFF
--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -6,7 +6,7 @@
   "description": "{package.json -> description}",
   "version": "{package.json -> version}",
   "author": "{package.json -> author}",
-  "permissions": [
+  "host_permissions": [
 	// Amazon S3 is used by GitHub to upload files. We need to have permissions on it,
 	// so we avoid cross-origin issues when mimicking the upload within the GitHubUploadAdapter class.
 	// Firefox only.
@@ -46,7 +46,7 @@
 	"96": "icons/github-writer-96.png",
 	"128": "icons/github-writer-128.png"
   },
-  "browser_action": {
+  "action": {
 	"default_popup": "popup/popup.html",
 	"default_title": "GitHub Writer"
   },
@@ -56,5 +56,5 @@
 	  "id": "github-writer@cksource.com"
 	}
   },
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
Updated manifest version as the current one will be deprecated in 2023 based on [google migration guide](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/). Closes: #320.