### PR TITLE
Fix for partial loading or not loading at all of the GitHub Writer

### DIFF
--- a/src/app/router.js
+++ b/src/app/router.js
@@ -124,15 +124,20 @@ export default router;
 
 // Handle editors inside pjax containers.
 {
-	document.addEventListener( 'pjax:start', ( { target } ) => {
+	document.addEventListener( 'turbo:before-visit', ( { target } ) => {
+		/* istanbul ignore next */
+		if ( process.env.NODE_ENV !== 'production' ) {
+			console.log( 'navigation started -> destroying editors', target );
+		}
+
 		Editor.destroyEditors( target );
 	}, { passive: true } );
 
-	document.addEventListener( 'pjax:end', () => {
+	document.addEventListener( 'turbo:render', () => {
 		setTimeout( () => {
 			/* istanbul ignore next */
 			if ( process.env.NODE_ENV !== 'production' ) {
-				console.log( `pjax ended -> running the router on "${ window.location.pathname }"` );
+				console.log( `navigation ended -> running the router on "${ window.location.pathname }"` );
 			}
 
 			router.run();

--- a/tests/unit/router.js
+++ b/tests/unit/router.js
@@ -56,22 +56,22 @@ describe( 'Router', () => {
 		} );
 	} );
 
-	describe( 'pjax', () => {
-		it( 'should destroy editors before pjax', () => {
+	describe( 'turbo', () => {
+		it( 'should destroy editors before turbo navigation', () => {
 			const stub = sinon.stub( Editor, 'destroyEditors' );
 			expect( stub.called, 'no call before' ).to.be.false;
 
-			document.body.dispatchEvent( new CustomEvent( 'pjax:start', { bubbles: true } ) );
+			document.body.dispatchEvent( new CustomEvent( 'turbo:before-visit', { bubbles: true } ) );
 
 			expect( stub.calledOnce, 'one call after' ).to.be.true;
 			expect( stub.firstCall.calledWith( document.body ) ).to.be.true;
 		} );
 
-		it( 'should re-scan after pjax', done => {
+		it( 'should re-scan after turbo rendering', done => {
 			const stub = sinon.stub( router, 'run' );
 			expect( stub.called, 'no call before' ).to.be.false;
 
-			document.body.dispatchEvent( new CustomEvent( 'pjax:end', { bubbles: true } ) );
+			document.body.dispatchEvent( new CustomEvent( 'turbo:render', { bubbles: true } ) );
 
 			setTimeout( () => {
 				expect( stub.calledOnce, 'one call after' ).to.be.true;


### PR DESCRIPTION
The GHW's router listened to pjax events to detect when it should destroy the old editors and initialize new ones. However, it seems that GH no longer uses the pjax and it uses [Turbo](https://turbo.hotwired.dev/) instead. I've replaced the pjax events with their [Turbo equivalents](https://turbo.hotwired.dev/reference/events):

*   `pjax:start` → `turbo:before-visit`,
*   `pjax:end` → `turbo:render`.

Thanks to that, the navigation between pages is correctly detected and handled and GHW is once again loading correctly.

Closes #337.