### PR TITLE
fix(popup): link typo to website

### DIFF
--- a/src/extension/popup/popup.html
+++ b/src/extension/popup/popup.html
@@ -103,7 +103,7 @@
 	</div>
 
 	<div class="footer">
-		<p>Made with ❤️ by the <a href="https://ckeditor.com/?github-writer" target="_blank" rel="noopener noreferrer">CKEditor</a>
+		<p>Made with ❤️ by the <a href="https://ckeditor.com/github-writer" target="_blank" rel="noopener noreferrer">CKEditor</a>
 			team</p>
 	</div>
 </div>


### PR DESCRIPTION
## closes #356 

## Changes proposed
- Add correct link to the site in `popup.html`