### PR TITLE
Wrong tooltip for markdown switch button

### DIFF
--- a/src/app/plugins/modeswitcher.js
+++ b/src/app/plugins/modeswitcher.js
@@ -30,7 +30,6 @@ export default class ModeSwitcher extends Plugin {
 			const view = new ButtonView( locale );
 
 			view.set( {
-				label: 'Edit markdown (nostalgia)',
 				icon,
 				class: 'github-writer-mode-button',
 				tooltip: true,
@@ -48,10 +47,10 @@ export default class ModeSwitcher extends Plugin {
 					view.set( 'isOn', isMarkdown );
 
 					if ( view.element ) {
-						// To make it fancy, let's change the tooltip as well.
-						view.element.setAttribute( 'aria-label', isMarkdown ?
+						// Set the correct label based on the editor mode.
+						view.set( { label: isMarkdown ?
 							'Switch to rich-text editing' :
-							view.label );
+							'Edit markdown (nostalgia)' } );
 					}
 				} );
 

--- a/tests/unit/plugins/modeswitcher.js
+++ b/tests/unit/plugins/modeswitcher.js
@@ -34,10 +34,6 @@ describe( 'Plugins', () => {
 			expect( button ).to.be.an.instanceOf( ButtonView );
 		} );
 
-		it( 'button should have a label', () => {
-			expect( button.label ).to.be.a( 'string' );
-		} );
-
 		it( 'button should have the right icon', () => {
 			expect( button.icon ).to.equals( icon );
 		} );
@@ -62,11 +58,11 @@ describe( 'Plugins', () => {
 
 			editor.setMode( Editor.modes.MARKDOWN );
 			expect( button.isOn ).to.be.true;
-			expect( button.element.getAttribute( 'aria-label' ) ).to.be.a( 'string' ).not.equals( button.label + '1' );
+			expect( button.label ).to.be.equal( 'Switch to rich-text editing' );
 
 			editor.setMode( Editor.modes.RTE );
 			expect( button.isOn ).to.be.false;
-			expect( button.element.getAttribute( 'aria-label' ) ).to.equals( button.label );
+			expect( button.label ).to.be.equal( 'Edit markdown (nostalgia)' );
 		} );
 
 		it( 'should switch modes on click', () => {


### PR DESCRIPTION
The tooltip for switching to/from markdown mode button, will now have the expected text. Closes #378.