### PR TITLE
Fixed CKE5 plugin paths in unit tests

### DIFF
--- a/tests/unit/dependencies/ckeditor5-markdown-gfm.js
+++ b/tests/unit/dependencies/ckeditor5-markdown-gfm.js
@@ -5,8 +5,8 @@
 
 import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting';
 import KbdEditing from '@mlewand/ckeditor5-keyboard-marker/src/KbdEditing';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
-import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolistediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
+import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolist/todolistediting';
 
 import { createTestEditor } from '../../_util/ckeditor';
 import { getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';

--- a/tests/unit/plugins/autoformat.js
+++ b/tests/unit/plugins/autoformat.js
@@ -15,8 +15,8 @@ import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockeditin
 import HeadingCommand from '@ckeditor/ckeditor5-heading/src/headingcommand';
 import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
 import HorizontalLineEditing from '@ckeditor/ckeditor5-horizontal-line/src/horizontallineediting';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
-import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolistediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
+import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolist/todolistediting';
 
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { createTestEditor } from '../../_util/ckeditor';


### PR DESCRIPTION
The change was actually very simple. Closes #392.