### PR TITLE
Updated failing test after recent ckeditor5 version bump

### DIFF
--- a/tests/unit/plugins/savedreplies.js
+++ b/tests/unit/plugins/savedreplies.js
@@ -108,7 +108,7 @@ describe( 'Plugins', () => {
 						component.render();
 						component.isOpen = true;
 
-						expect( list.focus.callCount ).to.equals( 1 );
+						expect( list.focus.callCount ).to.equals( 2 ); // #363
 					} );
 				} );
 			} );


### PR DESCRIPTION
Focus is called twice on opening a dropdown so one of the tests had to be updated. Closes #363.