### PR TITLE
Enabled GHW for replies

### DIFF
--- a/src/app/router.js
+++ b/src/app/router.js
@@ -83,7 +83,7 @@ const routes = {
 			features: [ WikiEditor ]
 		}
 	],
-	'/settings/replies': [
+	'saved_replies': [
 		{
 			pattern: /\/settings\/replies/,
 			features: [ SavedReplyEditor ]


### PR DESCRIPTION
Updated page name for replies in `router.js` so it loads correctly. Closes https://github.com/ckeditor/github-writer/issues/396.