### PR TITLE
Fix memory leaks

### DIFF
--- a/src/app/router.js
+++ b/src/app/router.js
@@ -122,12 +122,23 @@ const router = {
 
 export default router;
 
-// Handle editors inside pjax containers.
+// Handle editors inside turbo containers.
 {
-	document.addEventListener( 'turbo:before-visit', ( { target } ) => {
+	// Destroy all editors when a link is clicked (#416).
+	document.addEventListener( 'turbo:click', ( { target } ) => {
 		/* istanbul ignore next */
 		if ( process.env.NODE_ENV !== 'production' ) {
-			console.log( 'navigation started -> destroying editors', target );
+			console.log( 'navigation by click started -> destroying editors', target.getRootNode().documentElement );
+		}
+
+		Editor.destroyEditors( target.getRootNode().documentElement );
+	}, { passive: true } );
+
+	// Destroy all editors while using the browser navigation (#416).
+	document.addEventListener( 'turbo:visit', ( { target } ) => {
+		/* istanbul ignore next */
+		if ( process.env.NODE_ENV !== 'production' ) {
+			console.log( 'visit started -> destroying editors', target );
 		}
 
 		Editor.destroyEditors( target );

--- a/tests/unit/router.js
+++ b/tests/unit/router.js
@@ -57,11 +57,20 @@ describe( 'Router', () => {
 	} );
 
 	describe( 'turbo', () => {
-		it( 'should destroy editors before turbo navigation', () => {
+		it( 'should destroy editors on link navigation', () => {
 			const stub = sinon.stub( Editor, 'destroyEditors' );
 			expect( stub.called, 'no call before' ).to.be.false;
 
-			document.body.dispatchEvent( new CustomEvent( 'turbo:before-visit', { bubbles: true } ) );
+			document.body.dispatchEvent( new CustomEvent( 'turbo:click', { bubbles: true } ) );
+
+			expect( stub.calledOnce, 'one call after' ).to.be.true;
+		} );
+
+		it( 'should destroy editors on browser navigation', () => {
+			const stub = sinon.stub( Editor, 'destroyEditors' );
+			expect( stub.called, 'no call before' ).to.be.false;
+
+			document.body.dispatchEvent( new CustomEvent( 'turbo:visit', { bubbles: true } ) );
 
 			expect( stub.calledOnce, 'one call after' ).to.be.true;
 			expect( stub.firstCall.calledWith( document.body ) ).to.be.true;


### PR DESCRIPTION
To test the PR, build the dev version, open dev tools and navigate throughout GH. As long as there is no hard reload (console will clear then) you should see that every Writer instance that is created is also destroyed after leaving a page (follow the notes in console).

Closes #416.