### PR TITLE
Update test for focus in saved replies.

### DIFF
--- a/tests/unit/plugins/savedreplies.js
+++ b/tests/unit/plugins/savedreplies.js
@@ -101,7 +101,7 @@ describe( 'Plugins', () => {
 						component.render();
 						component.isOpen = true;
 
-						expect( list.focus.callCount ).to.equals( 1 ); // #363
+						expect( list.focus.callCount ).to.equals( 1 );
 					} );
 				} );
 			} );

--- a/tests/unit/plugins/savedreplies.js
+++ b/tests/unit/plugins/savedreplies.js
@@ -101,7 +101,7 @@ describe( 'Plugins', () => {
 						component.render();
 						component.isOpen = true;
 
-						expect( list.focus.callCount ).to.equals( 2 ); // #363
+						expect( list.focus.callCount ).to.equals( 1 ); // #363
 					} );
 				} );
 			} );


### PR DESCRIPTION
Updates test for focus in saved replies so it does not fail. Closes #421.

Additional information:
This fix was needed because we recently removed duplicated `focus()` call in https://github.com/ckeditor/github-writer/pull/395.