### PR TITLE
Don't try to create the editor at 'issues/new/choose' page

### DIFF
--- a/src/app/router.js
+++ b/src/app/router.js
@@ -35,7 +35,7 @@ const routes = {
 	],
 	'repo_issues': [
 		{
-			pattern: /\/issues\/new/,
+			pattern: /\/issues\/new$/,
 			features: [ NewIssueEditor ]
 		},
 		{


### PR DESCRIPTION
I decided to edit the regexp to avoid the attempt to create the editor on the `issues/new/choose` pages as it seemed the easiest thing to do, but there are other possibilities, e.g. perhaps the queries should be improved instead - I'm open for proposals.

Closes #426.