### PR TITLE
Double submit when commenting

### DIFF
--- a/src/app/editor/ckeditorgithubeditor.js
+++ b/src/app/editor/ckeditorgithubeditor.js
@@ -8,6 +8,7 @@ import GFMDataProcessor from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataproces
 import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
 import AttributeElement from '@ckeditor/ckeditor5-engine/src/view/attributeelement';
 
+import PendingActions from '@ckeditor/ckeditor5-core/src/pendingactions';
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Enter from '../plugins/enter';
@@ -118,5 +119,6 @@ CKEditorGitHubEditor.builtinPlugins = [
 	QuoteSelection, SavedReplies, Messenger, EditorExtras, ControlClick, SmartCaret,
 	CodeBlockLanguageSelector,
 	LiveModelData,
-	Mermaid
+	Mermaid,
+	PendingActions
 ];

--- a/tests/unit/editor/setupmixin.js
+++ b/tests/unit/editor/setupmixin.js
@@ -631,6 +631,21 @@ describe( 'Editor', () => {
 						expect( editor ).to.be.an.instanceOf( Editor );
 					} );
 			} );
+
+			it( 'should call "change:addAction" action', () => {
+				const editor = new Editor( GitHubPage.appendRoot( ) );
+
+				return editor.create()
+					.then( () => {
+						const event = new Event( 'submit' );
+						const spy = sinon.spy( event, 'change:addAction' );
+
+						const pendingActions = this.ckeditor.plugins.get( 'PendingActions' );
+						pendingActions.fire( 'change:addAction', 'submit' );
+
+						expect( spy.callCount ).to.equals( 1 );
+					} );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
\### Suggested merge commit message (\[convention\](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix ( Github Writer ): Double submit when commenting. Closes #227.

  
\---

\### Additional information

\_For example – encountered issues, assumptions you had to make, other affected tickets, etc.\_