### PR TITLE
Extension should work for Issues and Wiki pages

### DIFF
--- a/src/app/editor/editor.js
+++ b/src/app/editor/editor.js
@@ -123,7 +123,7 @@ export default class Editor {
 			 * @type {HTMLElement}
 			 * @memberOf MarkdownEditor#dom
 			 */
-			panelsContainer: root.querySelector( '.previewable-comment-form' ),
+			panelsContainer: root.querySelector( '.js-previewable-comment-form' ),
 
 			/**
 			 * The panels (body) of the markdown editor (Write and Preview).
@@ -138,7 +138,7 @@ export default class Editor {
 				 * @type {HTMLElement}
 				 * @memberOf MarkdownEditor#dom.panels
 				 */
-				markdown: root.querySelector( '.previewable-comment-form file-attachment' ),
+				markdown: root.querySelector( '.js-previewable-comment-form file-attachment' ),
 
 				/**
 				 * The preview panel.
@@ -149,13 +149,13 @@ export default class Editor {
 				preview:
 					root.querySelector(
 						// This one is used on New Issue and Add Comment.
-						'.previewable-comment-form .js-preview-panel,' +
+						'.js-previewable-comment-form .js-preview-panel,' +
 						// This one is used on Edit Comment (structure up to May 2023).
-						'.previewable-comment-form > .preview-content,' +
+						'.js-previewable-comment-form > .preview-content,' +
 						// Another selector for Edit Comment but this div looks rather buggy,
 						// so it might be that GH will clean this up soon, see
 						// https://github.com/ckeditor/github-writer/pull/455#discussion_r1224359359
-						'.previewable-comment-form > div > .preview-content' )
+						'.js-previewable-comment-form > div > .preview-content' )
 			},
 
 			tabs: {

--- a/src/app/features/wikieditor.js
+++ b/src/app/features/wikieditor.js
@@ -14,7 +14,7 @@ export default class WikiEditor extends Editor {
 		const dom = super.getDom( root );
 
 		dom.toolbarContainer = root.querySelector( '.comment-form-head' );
-		dom.panels.markdown = root.querySelector( '.previewable-comment-form > .write-content' );
+		dom.panels.markdown = root.querySelector( '.previewable-comment-form > file-attachment > .write-content' );
 
 		delete dom.toolbar;
 

--- a/src/app/features/wikieditor.js
+++ b/src/app/features/wikieditor.js
@@ -14,7 +14,7 @@ export default class WikiEditor extends Editor {
 		const dom = super.getDom( root );
 
 		dom.toolbarContainer = root.querySelector( '.comment-form-head' );
-		dom.panels.markdown = root.querySelector( '.previewable-comment-form > file-attachment > .write-content' );
+		dom.panels.markdown = root.querySelector( '.js-previewable-comment-form > file-attachment > .write-content' );
 
 		delete dom.toolbar;
 

--- a/src/github-writer.css
+++ b/src/github-writer.css
@@ -186,6 +186,11 @@ div.github-writer-panel-rte.form-control {
 	top: -1px;
 }
 
+/* Adjust editor layout after recent GH changes. See #470 */
+form.github-writer-revieweditor .github-writer-panel-rte.form-control {
+	margin-bottom: var(--stack-padding-normal, 16px) !important;
+}
+
 .js-comment-update div.github-writer-panel-rte.form-control {
 	top: 0;
 }

--- a/src/github-writer.css
+++ b/src/github-writer.css
@@ -32,8 +32,15 @@ div.github-writer-ckeditor .ck-editor__editable.ck.ck-content {
 	border-radius: 6px;
 }
 
+/* Top corners should not be rounded anymore. See #470 */
+div.github-writer-ckeditor .ck-editor__editable.ck.ck-content {
+	border-top-right-radius: 0;
+	border-top-left-radius: 0;
+}
+
+/* Keep the original background color on blur. See #470 */
 div.github-writer-ckeditor .ck-editor__editable.ck-blurred {
-	background-color: var(--color-canvas-inset);
+	background-color: var(--color-canvas-default);
 }
 
 div.github-writer-ckeditor .ck-editor__editable.ck-focused {
@@ -81,6 +88,12 @@ form.github-writer-type-milestone .ck-editor__editable {
 /* Remove the markdown message when in RTE. */
 .github-writer-mode-rte .tabnav-extra {
 	display: none;
+}
+
+/* Bottom corners should not by rounded anymore. See #470 */
+.github-writer-mode-rte .js-previewable-comment-form {
+	border-bottom-right-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 /* Markdown mode */
@@ -140,7 +153,7 @@ div.github-writer-ckeditor .ck-editor__editable.ck-focused {
 
 div.github-writer-ckeditor .ck-editor__editable {
 	border: none !important;
-	padding: 0 8px;
+	padding: 0 var(--stack-padding-normal, 16px);
 	width: 100%;
 }
 
@@ -164,6 +177,23 @@ div.github-writer-panel-rte.form-control {
 	width: auto;
 }
 
+/* Adjust editor layout after recent GH changes. See See #470 */
+div.github-writer-panel-rte.form-control {
+	margin: 0 !important;
+	border-top: none;
+	border-top-right-radius: 0;
+	border-top-left-radius: 0;
+	top: -1px;
+}
+
+.js-comment-update div.github-writer-panel-rte.form-control {
+	top: 0;
+}
+
+.js-comment-update div.github-writer-panel-rte.form-control {
+	border: none;
+}
+
 /* Do not show the arrow in the Kebab button. */
 .github-writer-kebab-button .ck-dropdown__arrow {
 	display: none;
@@ -182,7 +212,6 @@ form[data-github-writer-id]:not(.github-writer-type-code) div.comment-form-head 
 form[data-github-writer-id]:not(.github-writer-type-code) div.tabnav-tabs,
 form[data-github-writer-id]:not(.github-writer-type-code) nav.tabnav-tabs {
 	flex: auto;
-	margin: auto 8px -1px 8px !important;
 	order: -1;
 	white-space: nowrap;
 }
@@ -231,6 +260,11 @@ form[data-github-writer-id]:not(.github-writer-type-code) nav.tabnav-tabs {
 	background-color: var(--color-canvas-default) !important;
 }
 
+/* Remove the gab between toolbar and editor. See #470 */
+.github-writer-wikieditor .comment-form-head {
+	margin-bottom: 0;
+}
+
 /**********************************
 	Code editor specific stuff
 ***********************************/
@@ -277,7 +311,7 @@ form[data-github-writer-id]:not(.github-writer-type-code) nav.tabnav-tabs {
 .previewable-edit .github-writer-size-container {
 	display: none !important;
 }
-.is-comment-editing .github-writer-size-container.previewable-comment-form {
+.is-comment-editing .github-writer-size-container.js-previewable-comment-form {
 	display: flex !important;
 }
 

--- a/src/github-writer.css
+++ b/src/github-writer.css
@@ -177,7 +177,7 @@ div.github-writer-panel-rte.form-control {
 	width: auto;
 }
 
-/* Adjust editor layout after recent GH changes. See See #470 */
+/* Adjust editor layout after recent GH changes. See #470 */
 div.github-writer-panel-rte.form-control {
 	margin: 0 !important;
 	border-top: none;

--- a/tests/_util/githubpage.js
+++ b/tests/_util/githubpage.js
@@ -110,8 +110,8 @@ export const GitHubPage = {
 				root.classList.add( 'js-blob-form' );
 				root.querySelector( 'textarea' ).setAttribute( 'data-codemirror-mode', 'text/x-gfm' );
 
-				root.querySelector( '.previewable-comment-form > file-attachment' ).classList.add( 'commit-create' );
-				root.querySelector( '.previewable-comment-form > .preview-content' ).classList.add( 'commit-preview' );
+				root.querySelector( '.js-previewable-comment-form > file-attachment' ).classList.add( 'commit-create' );
+				root.querySelector( '.js-previewable-comment-form > .preview-content' ).classList.add( 'commit-preview' );
 
 				root.querySelector( 'markdown-toolbar' ).remove();
 				root.querySelector( '.tabnav-tabs' ).remove();

--- a/tests/_util/html/root.html
+++ b/tests/_util/html/root.html
@@ -4,8 +4,8 @@
   -->
 
 <!--suppress ALL -->
-<form action="/server" accept-charset="UTF-8" method="post" class="previewable-comment-form">
-	<tab-container class="previewable-comment-form" data-preview-url="/preview">
+<form action="/server" accept-charset="UTF-8" method="post" class="js-previewable-comment-form">
+	<tab-container class="js-previewable-comment-form" data-preview-url="/preview">
 		<file-attachment data-upload-repository-id="1234" data-upload-policy-url="/upload/policies/assets">
 			<textarea required></textarea>
 		</file-attachment>

--- a/tests/_util/html/root.html
+++ b/tests/_util/html/root.html
@@ -23,7 +23,9 @@
 
 	<!-- Wiki editor extras -->
 	<div class="comment-form-head"></div>
-	<div class="write-content"></div>
+	<file-attachment>
+		<div class="write-content"></div>
+	</file-attachment>
 
 	<!-- Code editor extras -->
 	<div class="file-header"></div>

--- a/tests/compat/issue-new.js
+++ b/tests/compat/issue-new.js
@@ -24,11 +24,11 @@ describe( 'Issue - New', function() {
 			'toolbar': root + ' markdown-toolbar',
 			'textarea': root + ' textarea',
 			'tab -> write': root + ' .write-tab',
-			'panels container': root + ' .previewable-comment-form',
-			'panel -> markdown': root + ' .previewable-comment-form > file-attachment',
+			'panels container': root + ' .js-previewable-comment-form',
+			'panel -> markdown': root + ' .js-previewable-comment-form > file-attachment',
 			'panel -> preview':
-				root + ' .previewable-comment-form > .js-preview-panel, ' +
-				root + ' .previewable-comment-form > .preview-content',
+				root + ' .js-previewable-comment-form > .js-preview-panel, ' +
+				root + ' .js-previewable-comment-form > .preview-content',
 			'buttons -> submit':
 				root + ' input[type=submit].btn-primary,' +
 				root + ' button[type=submit].btn-primary',


### PR DESCRIPTION
Extension should now work for Issues and Wiki pages in Chrome and Firefox.

Closes #470.